### PR TITLE
Highlight hyperedges with tooltip on hover

### DIFF
--- a/web-ui/frontend/src/components/HyperGraph/index.tsx
+++ b/web-ui/frontend/src/components/HyperGraph/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { Graphin } from '@antv/graphin';
 import { Spin, message } from 'antd';
 
@@ -37,12 +37,21 @@ const HyperGraph = ({
 }) => {
     const [data, setData] = useState(undefined);
     const [loading, setLoading] = useState(false);
+    const graphRef = useRef<any>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [hoveredHyperedgeKey, setHoveredHyperedgeKey] = useState<string | null>(null);
+    const [tooltip, setTooltip] = useState<{ visible: boolean; x: number; y: number; content: string }>({
+        visible: false,
+        x: 0,
+        y: 0,
+        content: '',
+    });
 
     // 获取vertex邻居数据
     const fetchVertexNeighbor = async (vId, db) => {
         if (!vId) {
-return;
-}
+            return;
+        }
 
         setLoading(true);
         try {
@@ -69,12 +78,37 @@ return;
         }
     }, [vertexId, database]);
 
+    const colorByHyperedgeKey = useMemo(() => {
+        if (!data) return {} as Record<string, string>;
+        const result: Record<string, string> = {};
+        const edgeKeys = Object.keys(data.edges || {});
+        for (let i = 0; i < edgeKeys.length; i++) {
+            result[edgeKeys[i]] = colors[i % colors.length];
+        }
+        return result;
+    }, [data]);
+
+    const buildHyperedgeTooltip = (key: string) => {
+        if (!data) return '';
+        const edge = data.edges?.[key] || {};
+        const nodes = key.split('|#|');
+        const title = edge.keywords ? String(edge.keywords) : `超边 (${nodes.length} 节点)`;
+        const desc = edge.description ? String(edge.description).split('<SEP>').slice(0, 2).join('；') : '';
+        return `
+            <div>
+                <div style="font-weight:600;margin-bottom:4px;">${title}</div>
+                <div style="margin-bottom:4px;">成员: ${nodes.join('、')}</div>
+                ${desc ? `<div>描述: ${desc}</div>` : ''}
+            </div>
+        `;
+    };
+
     const options = useMemo(() => {
         const hyperData = {
             nodes: [],
             edges: [],
         };
-        const plugins = [];
+        const plugins: any[] = [];
 
         if (data) {
             // 添加顶点
@@ -87,15 +121,12 @@ return;
             }
 
             // 创建样式函数
-            const createStyle = (baseColor) => ({
+            const createStyle = (baseColor: string, isHover: boolean) => ({
                 fill: baseColor,
-                stroke: baseColor,
-                // labelFill: '#fff',
-                // labelPadding: 2,
-                // labelBackgroundFill: baseColor,
-                // labelBackgroundRadius: 5,
-                // labelPlacement: 'center',
-                // labelAutoRotate: false,
+                stroke: isHover ? '#000' : baseColor,
+                lineWidth: isHover ? 3 : 1,
+                fillOpacity: isHover ? 0.2 : 0.12,
+                strokeOpacity: 1,
                 // bubblesets配置
                 maxRoutingIterations: 100,
                 maxMarchingIterations: 20,
@@ -116,19 +147,20 @@ return;
             const edgeKeys = Object.keys(data.edges);
             for (let i = 0; i < edgeKeys.length; i++) {
                 const key = edgeKeys[i];
-                const edge = data.edges[key];
                 const nodes = key.split('|#|');
+                const baseColor = colorByHyperedgeKey[key] || colors[i % colors.length];
+                const isHover = hoveredHyperedgeKey === key;
 
                 plugins.push({
                     key: `bubble-sets-${key}`,
                     type: 'bubble-sets',
                     members: nodes,
                     // labelText: edge.keywords || '',
-                    ...createStyle(colors[i % colors.length]),
+                    ...createStyle(baseColor, isHover),
                 });
             }
 
-            // 添加tooltip插件
+            // 添加tooltip插件（节点/边），超边使用自定义 tooltip
             if (showTooltip) {
                 plugins.push({
                     type: 'tooltip',
@@ -193,7 +225,65 @@ return;
             },
             plugins,
         };
-    }, [data, vertexId, showTooltip]);
+    }, [data, vertexId, showTooltip, hoveredHyperedgeKey, colorByHyperedgeKey]);
+
+    useEffect(() => {
+        const graph = (graphRef.current as any)?.graph;
+        if (!graph || !data) return;
+
+        const handleMouseMove = (e: any) => {
+            const target: any = e?.target;
+            let targetName = target?.cfg?.name || '';
+            let targetId = target?.cfg?.id || '';
+            // 尝试向父级查找
+            if (!targetName && target?.getParent) {
+                const p = target.getParent();
+                targetName = p?.cfg?.name || '';
+                targetId = p?.cfg?.id || targetId;
+            }
+
+            // 识别 bubble-sets 图形
+            const idOrName = `${targetName} ${targetId}`;
+            const match = idOrName.match(/bubble-sets-([^\s]+)/);
+            if (match && match[1]) {
+                const key = match[1];
+                if (hoveredHyperedgeKey !== key) {
+                    setHoveredHyperedgeKey(key);
+                }
+                if (showTooltip && containerRef.current) {
+                    const rect = containerRef.current.getBoundingClientRect();
+                    setTooltip({
+                        visible: true,
+                        x: e.canvasX - rect.left,
+                        y: e.canvasY - rect.top + 12,
+                        content: buildHyperedgeTooltip(key),
+                    });
+                }
+                return;
+            }
+
+            // 非超边区域，隐藏
+            if (hoveredHyperedgeKey) {
+                setHoveredHyperedgeKey(null);
+            }
+            if (tooltip.visible) {
+                setTooltip(t => ({ ...t, visible: false }));
+            }
+        };
+
+        const handleLeave = () => {
+            if (hoveredHyperedgeKey) setHoveredHyperedgeKey(null);
+            if (tooltip.visible) setTooltip(t => ({ ...t, visible: false }));
+        };
+
+        graph.on('mousemove', handleMouseMove);
+        graph.on('canvas:mouseleave', handleLeave);
+
+        return () => {
+            graph.off('mousemove', handleMouseMove);
+            graph.off('canvas:mouseleave', handleLeave);
+        };
+    }, [data, hoveredHyperedgeKey, showTooltip, tooltip.visible]);
 
     if (loading) {
         return (
@@ -225,10 +315,11 @@ return;
     }
 
     return (
-        <div style={{ height, width, ...containerStyle }}>
+        <div ref={containerRef} style={{ position: 'relative', height, width, ...containerStyle }}>
             <Graphin
                 options={options}
                 id={graphId}
+                ref={graphRef}
                 style={{ width: '100%', height: '100%' }}
                 error={() => {
                     return <div>
@@ -238,6 +329,24 @@ return;
                     </div>
                 }}
             />
+            {showTooltip && tooltip.visible && (
+                <div
+                    style={{
+                        position: 'absolute',
+                        left: tooltip.x,
+                        top: tooltip.y,
+                        background: 'rgba(0,0,0,0.75)',
+                        color: '#fff',
+                        padding: '8px 10px',
+                        borderRadius: 6,
+                        fontSize: 12,
+                        maxWidth: 320,
+                        pointerEvents: 'none',
+                        boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
+                    }}
+                    dangerouslySetInnerHTML={{ __html: tooltip.content }}
+                />
+            )}
         </div>
     );
 };

--- a/web-ui/frontend/src/components/HyperGraph/index.tsx
+++ b/web-ui/frontend/src/components/HyperGraph/index.tsx
@@ -231,25 +231,69 @@ const HyperGraph = ({
         const graph = (graphRef.current as any)?.graph;
         if (!graph || !data) return;
 
+        const findBubbleKeyFromShape = (shape: any): string | null => {
+            let current = shape;
+            for (let i = 0; i < 5 && current; i++) {
+                const name = current?.cfg?.name || '';
+                const id = current?.cfg?.id || '';
+                const idOrName = `${name} ${id}`;
+                const match = idOrName.match(/bubble-sets-([^\s]+)/);
+                if (match && match[1]) return match[1];
+                current = current?.getParent ? current.getParent() : null;
+            }
+            return null;
+        };
+
+        const approxDetectByBBox = (canvasX: number, canvasY: number): string | null => {
+            if (!data) return null;
+            const keys = Object.keys(data.edges || {});
+            // convert to graph coords
+            const pt = graph.getPointByCanvas?.(canvasX, canvasY) || { x: canvasX, y: canvasY };
+            const gx = pt.x;
+            const gy = pt.y;
+            // margin based on bubble style
+            const inflate = 60;
+            for (let i = 0; i < keys.length; i++) {
+                const key = keys[i];
+                const members: string[] = key.split('|#|');
+                let minX = Number.POSITIVE_INFINITY;
+                let minY = Number.POSITIVE_INFINITY;
+                let maxX = Number.NEGATIVE_INFINITY;
+                let maxY = Number.NEGATIVE_INFINITY;
+                let valid = false;
+                members.forEach((id) => {
+                    const item = graph.findById(id);
+                    const model = item?.getModel?.();
+                    if (model && typeof model.x === 'number' && typeof model.y === 'number') {
+                        valid = true;
+                        minX = Math.min(minX, model.x);
+                        minY = Math.min(minY, model.y);
+                        maxX = Math.max(maxX, model.x);
+                        maxY = Math.max(maxY, model.y);
+                    }
+                });
+                if (!valid) continue;
+                minX -= inflate; minY -= inflate; maxX += inflate; maxY += inflate;
+                if (gx >= minX && gx <= maxX && gy >= minY && gy <= maxY) {
+                    return key;
+                }
+            }
+            return null;
+        };
+
         const handleMouseMove = (e: any) => {
-            const target: any = e?.target;
-            let targetName = target?.cfg?.name || '';
-            let targetId = target?.cfg?.id || '';
-            // 尝试向父级查找
-            if (!targetName && target?.getParent) {
-                const p = target.getParent();
-                targetName = p?.cfg?.name || '';
-                targetId = p?.cfg?.id || targetId;
+            // try exact shape detection
+            const keyFromShape = findBubbleKeyFromShape(e?.target);
+            let key: string | null = keyFromShape;
+
+            // fallback approximate detection by bbox
+            if (!key) {
+                const pt = { x: e.canvasX, y: e.canvasY };
+                key = approxDetectByBBox(pt.x, pt.y);
             }
 
-            // 识别 bubble-sets 图形
-            const idOrName = `${targetName} ${targetId}`;
-            const match = idOrName.match(/bubble-sets-([^\s]+)/);
-            if (match && match[1]) {
-                const key = match[1];
-                if (hoveredHyperedgeKey !== key) {
-                    setHoveredHyperedgeKey(key);
-                }
+            if (key) {
+                if (hoveredHyperedgeKey !== key) setHoveredHyperedgeKey(key);
                 if (showTooltip && containerRef.current) {
                     const rect = containerRef.current.getBoundingClientRect();
                     setTooltip({
@@ -263,12 +307,8 @@ const HyperGraph = ({
             }
 
             // 非超边区域，隐藏
-            if (hoveredHyperedgeKey) {
-                setHoveredHyperedgeKey(null);
-            }
-            if (tooltip.visible) {
-                setTooltip(t => ({ ...t, visible: false }));
-            }
+            if (hoveredHyperedgeKey) setHoveredHyperedgeKey(null);
+            if (tooltip.visible) setTooltip(t => ({ ...t, visible: false }));
         };
 
         const handleLeave = () => {
@@ -277,10 +317,12 @@ const HyperGraph = ({
         };
 
         graph.on('mousemove', handleMouseMove);
+        graph.on('canvas:mousemove', handleMouseMove);
         graph.on('canvas:mouseleave', handleLeave);
 
         return () => {
             graph.off('mousemove', handleMouseMove);
+            graph.off('canvas:mousemove', handleMouseMove);
             graph.off('canvas:mouseleave', handleLeave);
         };
     }, [data, hoveredHyperedgeKey, showTooltip, tooltip.visible]);

--- a/web-ui/frontend/src/components/RetrievalHyperGraph/index.tsx
+++ b/web-ui/frontend/src/components/RetrievalHyperGraph/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState, useEffect } from 'react';
 import { Graphin } from '@antv/graphin';
 
 const colors = [
@@ -36,6 +36,15 @@ const RetrievalHyperGraph = ({
     mode = 'hyper' // 新增mode参数，默认为hyper模式
 }) => {
     const edgesName = mode === 'hyper' ? '超边' : '边'
+    const graphRef = useRef<any>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [hoveredHyperedgeKey, setHoveredHyperedgeKey] = useState<string | null>(null);
+    const [tooltip, setTooltip] = useState<{ visible: boolean; x: number; y: number; content: string }>({
+        visible: false,
+        x: 0,
+        y: 0,
+        content: '',
+    });
     // 转换数据格式为HyperGraph组件需要的格式
     const convertedData = useMemo(() => {
         // 如果没有数据，返回空
@@ -94,12 +103,37 @@ const RetrievalHyperGraph = ({
         return { vertices, edges };
     }, [entities, hyperedges]);
 
+    const colorsByKey = useMemo(() => {
+        if (!convertedData) return {} as Record<string, string>;
+        const m: Record<string, string> = {};
+        const keys = Object.keys(convertedData.edges || {});
+        for (let i = 0; i < keys.length; i++) {
+            m[keys[i]] = colors[i % colors.length];
+        }
+        return m;
+    }, [convertedData]);
+
+    const buildHyperedgeTooltip = (key: string) => {
+        if (!convertedData) return '';
+        const edge = convertedData.edges?.[key] || {};
+        const nodes = key.split('|#|');
+        const title = edge.keywords ? String(edge.keywords) : `超边 (${nodes.length} 节点)`;
+        const desc = edge.description ? String(edge.description).split('<SEP>').slice(0, 2).join('；') : '';
+        return `
+            <div>
+                <div style="font-weight:600;margin-bottom:4px;">${title}</div>
+                <div style="margin-bottom:4px;">成员: ${nodes.join('、')}</div>
+                ${desc ? `<div>描述: ${desc}</div>` : ''}
+            </div>
+        `;
+    };
+
     const options = useMemo(() => {
         const hyperData = {
             nodes: [],
             edges: [],
         };
-        const plugins = [];
+        const plugins: any[] = [];
 
         if (convertedData) {
             // 添加顶点
@@ -132,9 +166,12 @@ const RetrievalHyperGraph = ({
             } else {
                 // hyper模式：使用原有的bubble-sets插件
                 // 创建样式函数
-                const createStyle = (baseColor) => ({
+                const createStyle = (baseColor: string, isHover: boolean) => ({
                     fill: baseColor,
-                    stroke: baseColor,
+                    stroke: isHover ? '#000' : baseColor,
+                    lineWidth: isHover ? 3 : 1,
+                    fillOpacity: isHover ? 0.2 : 0.12,
+                    strokeOpacity: 1,
                     labelFill: '#fff',
                     labelPadding: 2,
                     labelBackgroundFill: baseColor,
@@ -161,20 +198,21 @@ const RetrievalHyperGraph = ({
                 const edgeKeys = Object.keys(convertedData.edges);
                 for (let i = 0; i < edgeKeys.length; i++) {
                     const key = edgeKeys[i];
-                    const edge = convertedData.edges[key];
                     const nodes = key.split('|#|');
+                    const baseColor = colorsByKey[key] || colors[i % colors.length];
+                    const isHover = hoveredHyperedgeKey === key;
 
                     plugins.push({
                         key: `bubble-sets-${key}`,
                         type: 'bubble-sets',
                         members: nodes,
                         // labelText: String(edge.keywords || ''), // 确保labelText是字符串
-                        ...createStyle(colors[i % colors.length]),
+                        ...createStyle(baseColor, isHover),
                     });
                 }
             }
 
-            // 添加tooltip插件
+            // 添加tooltip插件（节点/边），超边使用自定义 tooltip
             if (showTooltip) {
                 plugins.push({
                     type: 'tooltip',
@@ -239,7 +277,54 @@ const RetrievalHyperGraph = ({
             },
             plugins: mode === 'graph' ? (showTooltip ? plugins : []) : plugins,
         };
-    }, [convertedData, showTooltip, mode]);
+    }, [convertedData, showTooltip, mode, hoveredHyperedgeKey, colorsByKey]);
+
+    useEffect(() => {
+        if (mode !== 'hyper') return;
+        const graph = (graphRef.current as any)?.graph;
+        if (!graph || !convertedData) return;
+
+        const handleMouseMove = (e: any) => {
+            const target: any = e?.target;
+            let targetName = target?.cfg?.name || '';
+            let targetId = target?.cfg?.id || '';
+            if (!targetName && target?.getParent) {
+                const p = target.getParent();
+                targetName = p?.cfg?.name || '';
+                targetId = p?.cfg?.id || targetId;
+            }
+            const idOrName = `${targetName} ${targetId}`;
+            const match = idOrName.match(/bubble-sets-([^\s]+)/);
+            if (match && match[1]) {
+                const key = match[1];
+                if (hoveredHyperedgeKey !== key) setHoveredHyperedgeKey(key);
+                if (showTooltip && containerRef.current) {
+                    const rect = containerRef.current.getBoundingClientRect();
+                    setTooltip({
+                        visible: true,
+                        x: e.canvasX - rect.left,
+                        y: e.canvasY - rect.top + 12,
+                        content: buildHyperedgeTooltip(key),
+                    });
+                }
+                return;
+            }
+            if (hoveredHyperedgeKey) setHoveredHyperedgeKey(null);
+            if (tooltip.visible) setTooltip(t => ({ ...t, visible: false }));
+        };
+
+        const handleLeave = () => {
+            if (hoveredHyperedgeKey) setHoveredHyperedgeKey(null);
+            if (tooltip.visible) setTooltip(t => ({ ...t, visible: false }));
+        };
+
+        graph.on('mousemove', handleMouseMove);
+        graph.on('canvas:mouseleave', handleLeave);
+        return () => {
+            graph.off('mousemove', handleMouseMove);
+            graph.off('canvas:mouseleave', handleLeave);
+        };
+    }, [mode, convertedData, hoveredHyperedgeKey, showTooltip, tooltip.visible]);
 
     // 如果没有数据，不显示组件
     if (!convertedData || (!entities.length && !hyperedges.length)) {
@@ -261,29 +346,50 @@ const RetrievalHyperGraph = ({
                     {edgesName}: {hyperedges.length}
                 </span>
             </div>
-            <Graphin
-                options={options}
-                id={graphId}
-                style={{
-                    width: '100%',
-                    height: 'calc(100% - 30px)',
-                    border: '1px solid #e0e0e0',
-                    borderRadius: '6px'
-                }}
-                error={() => {
-                    return (
-                        <div style={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            alignItems: 'center',
-                            height: '100%',
-                            color: '#999'
-                        }}>
-                            图表加载失败
-                        </div>
-                    );
-                }}
-            />
+            <div ref={containerRef} style={{ position: 'relative', width: '100%', height: 'calc(100% - 30px)' }}>
+                <Graphin
+                    options={options}
+                    id={graphId}
+                    ref={graphRef}
+                    style={{
+                        width: '100%',
+                        height: '100%',
+                        border: '1px solid #e0e0e0',
+                        borderRadius: '6px'
+                    }}
+                    error={() => {
+                        return (
+                            <div style={{
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                                height: '100%',
+                                color: '#999'
+                            }}>
+                                图表加载失败
+                            </div>
+                        );
+                    }}
+                />
+                {mode === 'hyper' && showTooltip && tooltip.visible && (
+                    <div
+                        style={{
+                            position: 'absolute',
+                            left: tooltip.x,
+                            top: tooltip.y,
+                            background: 'rgba(0,0,0,0.75)',
+                            color: '#fff',
+                            padding: '8px 10px',
+                            borderRadius: 6,
+                            fontSize: 12,
+                            maxWidth: 320,
+                            pointerEvents: 'none',
+                            boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
+                        }}
+                        dangerouslySetInnerHTML={{ __html: tooltip.content }}
+                    />)
+                }
+            </div>
         </div>
     );
 };

--- a/web-ui/frontend/src/components/RetrievalHyperGraph/index.tsx
+++ b/web-ui/frontend/src/components/RetrievalHyperGraph/index.tsx
@@ -284,19 +284,61 @@ const RetrievalHyperGraph = ({
         const graph = (graphRef.current as any)?.graph;
         if (!graph || !convertedData) return;
 
-        const handleMouseMove = (e: any) => {
-            const target: any = e?.target;
-            let targetName = target?.cfg?.name || '';
-            let targetId = target?.cfg?.id || '';
-            if (!targetName && target?.getParent) {
-                const p = target.getParent();
-                targetName = p?.cfg?.name || '';
-                targetId = p?.cfg?.id || targetId;
+        const findBubbleKeyFromShape = (shape: any): string | null => {
+            let current = shape;
+            for (let i = 0; i < 5 && current; i++) {
+                const name = current?.cfg?.name || '';
+                const id = current?.cfg?.id || '';
+                const idOrName = `${name} ${id}`;
+                const match = idOrName.match(/bubble-sets-([^\s]+)/);
+                if (match && match[1]) return match[1];
+                current = current?.getParent ? current.getParent() : null;
             }
-            const idOrName = `${targetName} ${targetId}`;
-            const match = idOrName.match(/bubble-sets-([^\s]+)/);
-            if (match && match[1]) {
-                const key = match[1];
+            return null;
+        };
+
+        const approxDetectByBBox = (canvasX: number, canvasY: number): string | null => {
+            if (!convertedData) return null;
+            const keys = Object.keys(convertedData.edges || {});
+            const pt = graph.getPointByCanvas?.(canvasX, canvasY) || { x: canvasX, y: canvasY };
+            const gx = pt.x;
+            const gy = pt.y;
+            const inflate = 60;
+            for (let i = 0; i < keys.length; i++) {
+                const key = keys[i];
+                const members: string[] = key.split('|#|');
+                let minX = Number.POSITIVE_INFINITY;
+                let minY = Number.POSITIVE_INFINITY;
+                let maxX = Number.NEGATIVE_INFINITY;
+                let maxY = Number.NEGATIVE_INFINITY;
+                let valid = false;
+                members.forEach((id) => {
+                    const item = graph.findById(id);
+                    const model = item?.getModel?.();
+                    if (model && typeof model.x === 'number' && typeof model.y === 'number') {
+                        valid = true;
+                        minX = Math.min(minX, model.x);
+                        minY = Math.min(minY, model.y);
+                        maxX = Math.max(maxX, model.x);
+                        maxY = Math.max(maxY, model.y);
+                    }
+                });
+                if (!valid) continue;
+                minX -= inflate; minY -= inflate; maxX += inflate; maxY += inflate;
+                if (gx >= minX && gx <= maxX && gy >= minY && gy <= maxY) {
+                    return key;
+                }
+            }
+            return null;
+        };
+
+        const handleMouseMove = (e: any) => {
+            const keyFromShape = findBubbleKeyFromShape(e?.target);
+            let key: string | null = keyFromShape;
+            if (!key) {
+                key = approxDetectByBBox(e.canvasX, e.canvasY);
+            }
+            if (key) {
                 if (hoveredHyperedgeKey !== key) setHoveredHyperedgeKey(key);
                 if (showTooltip && containerRef.current) {
                     const rect = containerRef.current.getBoundingClientRect();
@@ -319,9 +361,11 @@ const RetrievalHyperGraph = ({
         };
 
         graph.on('mousemove', handleMouseMove);
+        graph.on('canvas:mousemove', handleMouseMove);
         graph.on('canvas:mouseleave', handleLeave);
         return () => {
             graph.off('mousemove', handleMouseMove);
+            graph.off('canvas:mousemove', handleMouseMove);
             graph.off('canvas:mouseleave', handleLeave);
         };
     }, [mode, convertedData, hoveredHyperedgeKey, showTooltip, tooltip.visible]);


### PR DESCRIPTION
Implement hyperedge hover highlight and custom tooltip to display hyperedge information on mouseover.

---
<a href="https://cursor.com/background-agent?bcId=bc-eba6ff8a-1b43-49af-ae21-298b584d3981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eba6ff8a-1b43-49af-ae21-298b584d3981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

